### PR TITLE
refactor: moves get all pets to table with loading - closes #24

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,7 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { Routes, Route } from 'react-router-dom';
 import { ToastContainer } from 'react-toastify';
 import { styled } from '@mui/material/styles';
-import { ClipLoader } from 'react-spinners';
 
 import { ProtectedRoute, PublicRoute } from './routes/Routes';
 
@@ -14,12 +13,10 @@ import { Dashboard } from './pages/Dashboard';
 import { useGlobalContext } from './context/Store';
 import { types } from './context/actions';
 
-import { cleanPetData } from './utils/helpers';
 import { readUserPersistence } from './utils/localStorage';
 import { toast } from './utils/toast';
 
 import './App.css';
-import { getAllPets } from './utils/api';
 
 const StyledHero = styled('div')(() => ({
   background:
@@ -35,33 +32,18 @@ const App = () => {
     state: { loggedIn },
     dispatch,
   } = useGlobalContext();
-  const [loading, setLoading] = useState(false);
-
-  const getPets = useCallback(async () => {
-    try {
-      setLoading(true);
-      const res = await getAllPets();
-      const pets = await res.json();
-      const cleanPets = cleanPetData(pets);
-      setLoading(false);
-    } catch (err) {
-      console.log(err);
-    }
-  }, []);
 
   useEffect(() => {
     const user = readUserPersistence();
     Object.keys(user).length && dispatch({ type: types.ME, payload: user });
     Object.keys(user).length && toast('Already logged in!', 600);
-    getPets();
-  }, [dispatch, getPets]);
+  }, [dispatch]);
 
   return (
     <div className="App">
       <Header />
       <StyledHero />
       <ToastContainer />
-      <ClipLoader color={'blue'} loading={loading} css={''} size={100} />
       <main>
         <Routes>
           <Route

--- a/src/components/table/DataTable.tsx
+++ b/src/components/table/DataTable.tsx
@@ -1,9 +1,13 @@
-import { FC } from 'react';
+import { FC, useCallback, useEffect, useState } from 'react';
+import { ClipLoader } from 'react-spinners';
 
 import { DataGrid } from '@mui/x-data-grid';
 import { Chip } from '@mui/material';
 
 import { Cols } from './Cols';
+
+import { getAllPets } from '../../utils/api';
+import { cleanPetData } from '../../utils/helpers';
 
 import { styled } from '@mui/material/styles';
 // import { css } from "@emotion/react";
@@ -20,11 +24,33 @@ const StyledTableContainer = styled('div')(() => ({
 const StyledTable = styled('div')(() => ({ flexGrow: 1 }));
 
 export const DataTable: FC = () => {
-  return (
+  const [loading, setLoading] = useState(false);
+  const [pets, setPets] = useState([]);
+
+  const getPets = useCallback(async () => {
+    try {
+      setLoading(true);
+      const res = await getAllPets();
+      const pets = await res.json();
+      const cleanPets = cleanPetData(pets);
+      setPets(cleanPets);
+      setLoading(false);
+    } catch (err) {
+      console.log(err);
+    }
+  }, []);
+
+  useEffect(() => {
+    getPets();
+  }, [getPets]);
+
+  return loading ? (
+    <ClipLoader color={'blue'} loading={loading} css={''} size={100} />
+  ) : (
     <StyledTableContainer>
       <StyledTable>
         <DataGrid
-          rows={[]}
+          rows={pets}
           columns={Cols}
           autoHeight={true}
           density="comfortable"


### PR DESCRIPTION
Refactor get all pet data from top level to data table and add conditional render of loading spinner instead of empty table while data request is pending